### PR TITLE
GCloud state backend: coding style fixes

### DIFF
--- a/backend/remote-state/gcloud/backend.go
+++ b/backend/remote-state/gcloud/backend.go
@@ -57,8 +57,6 @@ func (b *Backend) configure(ctx context.Context) error {
 		return nil
 	}
 
-	storageOAuth2Scope := "https://www.googleapis.com/auth/devstorage.read_write"
-
 	data := schema.FromContextBackendConfig(ctx)
 
 	b.bucketName = data.Get("bucket").(string)
@@ -75,14 +73,14 @@ func (b *Backend) configure(ctx context.Context) error {
 			return fmt.Errorf("Error loading credentials: %v", err)
 		}
 
-		jwtConfig, err := google.JWTConfigFromJSON([]byte(credentialsJson), storageOAuth2Scope)
+		jwtConfig, err := google.JWTConfigFromJSON([]byte(credentialsJson), storage.ScopeReadWrite)
 		if err != nil {
 			return fmt.Errorf("Failed to get Google OAuth2 token: %v", err)
 		}
 
 		tokenSource = jwtConfig.TokenSource(b.storageContext)
 	} else {
-		defaultTokenSource, err := google.DefaultTokenSource(b.storageContext, storageOAuth2Scope)
+		defaultTokenSource, err := google.DefaultTokenSource(b.storageContext, storage.ScopeReadWrite)
 		if err != nil {
 			return fmt.Errorf("Failed to get Google Application Default Credentials: %v", err)
 		}

--- a/backend/remote-state/gcloud/backend.go
+++ b/backend/remote-state/gcloud/backend.go
@@ -58,11 +58,16 @@ func (b *Backend) configure(ctx context.Context) error {
 		return nil
 	}
 
-	data := schema.FromContextBackendConfig(ctx)
+	// ctx is a background context with the backend config added.
+	// Since no context is passed to RemoteClient.Get(), .Lock(), etc. but
+	// one is required for calling the GCP API, we're holding on to this
+	// context here and re-use it later.
+	b.storageContext = ctx
+
+	data := schema.FromContextBackendConfig(b.storageContext)
 
 	b.bucketName = data.Get("bucket").(string)
 	b.stateDir = data.Get("state_dir").(string)
-	b.storageContext = googleContext.Background()
 
 	var tokenSource oauth2.TokenSource
 

--- a/backend/remote-state/gcloud/backend.go
+++ b/backend/remote-state/gcloud/backend.go
@@ -13,6 +13,16 @@ import (
 	"google.golang.org/api/option"
 )
 
+type Backend struct {
+	*schema.Backend
+
+	storageClient  *storage.Client
+	storageContext googleContext.Context
+
+	bucketName string
+	stateDir   string
+}
+
 func New() backend.Backend {
 	s := &schema.Backend{
 		Schema: map[string]*schema.Schema{
@@ -40,16 +50,6 @@ func New() backend.Backend {
 	result := &Backend{Backend: s}
 	result.Backend.ConfigureFunc = result.configure
 	return result
-}
-
-type Backend struct {
-	*schema.Backend
-
-	storageClient  *storage.Client
-	storageContext googleContext.Context
-
-	bucketName string
-	stateDir   string
 }
 
 func (b *Backend) configure(ctx context.Context) error {

--- a/backend/remote-state/gcloud/backend.go
+++ b/backend/remote-state/gcloud/backend.go
@@ -1,9 +1,10 @@
 package gcloud
 
 import (
-	"cloud.google.com/go/storage"
 	"context"
 	"fmt"
+
+	"cloud.google.com/go/storage"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/helper/pathorcontents"
 	"github.com/hashicorp/terraform/helper/schema"

--- a/backend/remote-state/gcloud/backend_state.go
+++ b/backend/remote-state/gcloud/backend_state.go
@@ -64,7 +64,7 @@ func (b *Backend) DeleteState(name string) error {
 
 	err = client.Delete()
 	if err != nil {
-		return fmt.Errorf("Failed to delete state file %v: %v", client.stateFileUrl(), err)
+		return fmt.Errorf("Failed to delete state file %v: %v", client.stateFileURL(), err)
 	}
 
 	return nil
@@ -104,7 +104,7 @@ func (b *Backend) State(name string) (state.State, error) {
 	// Local helper function so we can call it multiple places
 	lockUnlock := func(parent error) error {
 		if err := stateMgr.Unlock(lockId); err != nil {
-			return fmt.Errorf(strings.TrimSpace(errStateUnlock), lockId, client.lockFileUrl(), err)
+			return fmt.Errorf(strings.TrimSpace(errStateUnlock), lockId, client.lockFileURL(), err)
 		}
 
 		return parent

--- a/backend/remote-state/gcloud/backend_state.go
+++ b/backend/remote-state/gcloud/backend_state.go
@@ -1,17 +1,18 @@
 package gcloud
 
 import (
-	"cloud.google.com/go/storage"
 	"errors"
 	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"cloud.google.com/go/storage"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/state/remote"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/iterator"
-	"regexp"
-	"sort"
-	"strings"
 )
 
 func (b *Backend) States() ([]string, error) {

--- a/backend/remote-state/gcloud/client.go
+++ b/backend/remote-state/gcloud/client.go
@@ -65,9 +65,7 @@ func (c *RemoteClient) Put(data []byte) error {
 }
 
 func (c *RemoteClient) Delete() error {
-	err := c.stateFile().Delete(c.storageContext)
-
-	if err != nil {
+	if err := c.stateFile().Delete(c.storageContext); err != nil {
 		return fmt.Errorf("Failed to delete state file %v: %v", c.stateFileURL(), err)
 	}
 

--- a/backend/remote-state/gcloud/client.go
+++ b/backend/remote-state/gcloud/client.go
@@ -1,14 +1,15 @@
 package gcloud
 
 import (
-	"cloud.google.com/go/storage"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+
+	"cloud.google.com/go/storage"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/state/remote"
 	"golang.org/x/net/context"
-	"io/ioutil"
 )
 
 type RemoteClient struct {

--- a/backend/remote-state/gcloud/client.go
+++ b/backend/remote-state/gcloud/client.go
@@ -50,11 +50,13 @@ func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 }
 
 func (c *RemoteClient) Put(data []byte) error {
-	stateFileWriter := c.stateFile().NewWriter(c.storageContext)
-
-	stateFileWriter.Write(data)
-	err := stateFileWriter.Close()
-
+	err := func() error {
+		stateFileWriter := c.stateFile().NewWriter(c.storageContext)
+		if _, err := stateFileWriter.Write(data); err != nil {
+			return err
+		}
+		return stateFileWriter.Close()
+	}()
 	if err != nil {
 		return fmt.Errorf("Failed to upload state to %v: %v", c.stateFileURL(), err)
 	}


### PR DESCRIPTION
Here are my changes to the GCloud implementation, as mentioned in hashicorp/terraform#15592.

Noteworthy changes are:

1.  Return the GCS object's *generation* as the lock ID. This allows `Unlock()` to call "delete if generation matches" immediately, removing one round-trip.
2.  Hold on to the context passed to the `configure()` callback to avoid calling `context.Background()`.

Any feedback is welcome :)

Best regards,
—octo